### PR TITLE
Update Flux components to v0.5.7 [ci-skip]

### DIFF
--- a/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
+++ b/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
@@ -1,3 +1,6 @@
+---
+# GitOps Toolkit revision latest
+# Components: source-controller,kustomize-controller,helm-controller,notification-controller
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -2414,3 +2417,4 @@ spec:
   podSelector: {}
   policyTypes:
   - Ingress
+---


### PR DESCRIPTION
Release notes: https://github.com/fluxcd/flux2/releases/tag/v0.5.7