### PR TITLE
Update Flux components to v0.6.2 [ci-skip]

### DIFF
--- a/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
+++ b/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
@@ -1865,6 +1865,8 @@ spec:
                 - bitbucket
                 - harbor
                 - dockerhub
+                - quay
+                - gcr
                 type: string
             required:
             - resources
@@ -2104,7 +2106,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/helm-controller:v0.5.1
+        image: ghcr.io/fluxcd/helm-controller:v0.5.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -2175,7 +2177,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/kustomize-controller:v0.6.2
+        image: ghcr.io/fluxcd/kustomize-controller:v0.6.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -2247,7 +2249,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/notification-controller:v0.6.1
+        image: ghcr.io/fluxcd/notification-controller:v0.6.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -2324,7 +2326,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/source-controller:v0.6.1
+        image: ghcr.io/fluxcd/source-controller:v0.6.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Release notes: https://github.com/fluxcd/flux2/releases/tag/v0.6.2