### PR TITLE
Update Flux components to v0.7.5 [ci-skip]

### DIFF
--- a/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
+++ b/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
@@ -2296,7 +2296,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/kustomize-controller:v0.7.2
+        image: ghcr.io/fluxcd/kustomize-controller:v0.7.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -2447,18 +2447,20 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/source-controller:v0.7.1
+        image: ghcr.io/fluxcd/source-controller:v0.7.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
-            path: /
-            port: http
+            path: /healthz
+            port: healthz
         name: manager
         ports:
         - containerPort: 9090
           name: http
         - containerPort: 8080
           name: http-prom
+        - containerPort: 9440
+          name: healthz
         readinessProbe:
           httpGet:
             path: /


### PR DESCRIPTION
Release notes: https://github.com/fluxcd/flux2/releases/tag/v0.7.5