### PR TITLE
Update Flux components to v0.7.6 [ci-skip]

### DIFF
--- a/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
+++ b/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
@@ -2296,7 +2296,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/kustomize-controller:v0.7.3
+        image: ghcr.io/fluxcd/kustomize-controller:v0.7.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -2425,6 +2425,8 @@ spec:
   selector:
     matchLabels:
       app: source-controller
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:
@@ -2447,7 +2449,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/source-controller:v0.7.2
+        image: ghcr.io/fluxcd/source-controller:v0.7.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Release notes: https://github.com/fluxcd/flux2/releases/tag/v0.7.6