### PR TITLE
Update Flux components to v0.7.7 [ci-skip]

### DIFF
--- a/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
+++ b/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
@@ -1,3 +1,6 @@
+---
+# GitOps Toolkit revision latest
+# Components: source-controller,kustomize-controller,helm-controller,notification-controller
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -2544,3 +2547,4 @@ spec:
   policyTypes:
   - Ingress
   - Egress
+---


### PR DESCRIPTION
Release notes: https://github.com/fluxcd/flux2/releases/tag/v0.7.7