### PR TITLE
Update Flux components to v0.11.0 [ci-skip]

### DIFF
--- a/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
+++ b/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
@@ -1,3 +1,6 @@
+---
+# Flux version: v0.11.0
+# Components: source-controller,kustomize-controller,helm-controller,notification-controller
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -2751,3 +2754,4 @@ spec:
   policyTypes:
   - Ingress
   - Egress
+---


### PR DESCRIPTION
Release notes: https://github.com/fluxcd/flux2/releases/tag/v0.11.0