### PR TITLE
Update Flux components to v0.13.2 [ci-skip]

### DIFF
--- a/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
+++ b/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
@@ -1,10 +1,13 @@
+---
+# Flux version: v0.13.2
+# Components: source-controller,kustomize-controller,helm-controller,notification-controller
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: flux-system
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -16,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: alerts.notification.toolkit.fluxcd.io
 spec:
   group: notification.toolkit.fluxcd.io
@@ -191,7 +194,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: buckets.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
@@ -379,7 +382,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: gitrepositories.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
@@ -600,7 +603,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: helmcharts.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
@@ -799,7 +802,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: helmreleases.helm.toolkit.fluxcd.io
 spec:
   group: helm.toolkit.fluxcd.io
@@ -1334,7 +1337,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: helmrepositories.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
@@ -1504,7 +1507,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: kustomizations.kustomize.toolkit.fluxcd.io
 spec:
   group: kustomize.toolkit.fluxcd.io
@@ -1901,7 +1904,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: providers.notification.toolkit.fluxcd.io
 spec:
   group: notification.toolkit.fluxcd.io
@@ -2057,7 +2060,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: receivers.notification.toolkit.fluxcd.io
 spec:
   group: notification.toolkit.fluxcd.io
@@ -2237,7 +2240,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: helm-controller
   namespace: flux-system
 ---
@@ -2247,7 +2250,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: kustomize-controller
   namespace: flux-system
 ---
@@ -2257,7 +2260,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: notification-controller
   namespace: flux-system
 ---
@@ -2267,7 +2270,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: source-controller
   namespace: flux-system
 ---
@@ -2277,7 +2280,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: crd-controller-flux-system
 rules:
 - apiGroups:
@@ -2357,7 +2360,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: cluster-reconciler-flux-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2377,7 +2380,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: crd-controller-flux-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2409,7 +2412,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
     control-plane: controller
   name: notification-controller
   namespace: flux-system
@@ -2429,7 +2432,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
     control-plane: controller
   name: source-controller
   namespace: flux-system
@@ -2449,7 +2452,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
     control-plane: controller
   name: webhook-receiver
   namespace: flux-system
@@ -2469,7 +2472,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
     control-plane: controller
   name: helm-controller
   namespace: flux-system
@@ -2542,7 +2545,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
     control-plane: controller
   name: kustomize-controller
   namespace: flux-system
@@ -2571,7 +2574,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/kustomize-controller:v0.11.1
+        image: ghcr.io/fluxcd/kustomize-controller:v0.12.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -2617,7 +2620,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
     control-plane: controller
   name: notification-controller
   namespace: flux-system
@@ -2693,7 +2696,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
     control-plane: controller
   name: source-controller
   namespace: flux-system
@@ -2777,7 +2780,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: allow-egress
   namespace: flux-system
 spec:
@@ -2797,7 +2800,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: allow-scraping
   namespace: flux-system
 spec:
@@ -2817,7 +2820,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.13.1
+    app.kubernetes.io/version: v0.13.2
   name: allow-webhooks
   namespace: flux-system
 spec:
@@ -2829,3 +2832,4 @@ spec:
       app: notification-controller
   policyTypes:
   - Ingress
+---


### PR DESCRIPTION
Release notes: https://github.com/fluxcd/flux2/releases/tag/v0.13.2