### PR TITLE
Update Flux components to v0.13.2 [ci-skip]

### DIFF
--- a/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
+++ b/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
@@ -1,5 +1,4 @@
 ---
-=======
 # Flux version: v0.13.2
 # Components: source-controller,kustomize-controller,helm-controller,notification-controller
 apiVersion: v1


### PR DESCRIPTION
Release notes: https://github.com/fluxcd/flux2/releases/tag/v0.13.2