### PR TITLE
Update Flux components to v0.13.4 [ci-skip]

### DIFF
--- a/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
+++ b/cluster/uk.msrpi.com/flux-system/gotk-components.yaml
@@ -2648,7 +2648,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/notification-controller:v0.14.0
+        image: ghcr.io/fluxcd/notification-controller:v0.13.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Release notes: https://github.com/fluxcd/flux2/releases/tag/v0.13.4