### PR TITLE
Update Flux components to v0.16.1 [ci-skip]

### DIFF
--- a/cluster/base/flux-system/gotk-components.yaml
+++ b/cluster/base/flux-system/gotk-components.yaml
@@ -1,11 +1,13 @@
 ---
+# Flux version: v0.16.1
+# Components: source-controller,kustomize-controller,helm-controller,notification-controller
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: flux-system
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -17,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: alerts.notification.toolkit.fluxcd.io
 spec:
   group: notification.toolkit.fluxcd.io
@@ -227,7 +229,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: buckets.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
@@ -457,7 +459,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: gitrepositories.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
@@ -788,7 +790,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: helmcharts.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
@@ -1033,7 +1035,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: helmreleases.helm.toolkit.fluxcd.io
 spec:
   group: helm.toolkit.fluxcd.io
@@ -1781,7 +1783,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: helmrepositories.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
@@ -1999,7 +2001,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: kustomizations.kustomize.toolkit.fluxcd.io
 spec:
   group: kustomize.toolkit.fluxcd.io
@@ -2548,7 +2550,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: providers.notification.toolkit.fluxcd.io
 spec:
   group: notification.toolkit.fluxcd.io
@@ -2737,7 +2739,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: receivers.notification.toolkit.fluxcd.io
 spec:
   group: notification.toolkit.fluxcd.io
@@ -2952,7 +2954,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: helm-controller
   namespace: flux-system
 ---
@@ -2962,7 +2964,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: kustomize-controller
   namespace: flux-system
 ---
@@ -2972,7 +2974,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: notification-controller
   namespace: flux-system
 ---
@@ -2982,7 +2984,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: source-controller
   namespace: flux-system
 ---
@@ -2992,7 +2994,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: crd-controller-flux-system
 rules:
 - apiGroups:
@@ -3072,7 +3074,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: cluster-reconciler-flux-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3092,7 +3094,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: crd-controller-flux-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3124,7 +3126,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
     control-plane: controller
   name: notification-controller
   namespace: flux-system
@@ -3144,7 +3146,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
     control-plane: controller
   name: source-controller
   namespace: flux-system
@@ -3164,7 +3166,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
     control-plane: controller
   name: webhook-receiver
   namespace: flux-system
@@ -3184,7 +3186,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
     control-plane: controller
   name: helm-controller
   namespace: flux-system
@@ -3257,7 +3259,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
     control-plane: controller
   name: kustomize-controller
   namespace: flux-system
@@ -3286,7 +3288,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/kustomize-controller:v0.13.1
+        image: ghcr.io/fluxcd/kustomize-controller:v0.13.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -3332,7 +3334,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
     control-plane: controller
   name: notification-controller
   namespace: flux-system
@@ -3408,7 +3410,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
     control-plane: controller
   name: source-controller
   namespace: flux-system
@@ -3492,7 +3494,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: allow-egress
   namespace: flux-system
 spec:
@@ -3512,7 +3514,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: allow-scraping
   namespace: flux-system
 spec:
@@ -3532,7 +3534,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.16.1
   name: allow-webhooks
   namespace: flux-system
 spec:
@@ -3544,3 +3546,4 @@ spec:
       app: notification-controller
   policyTypes:
   - Ingress
+---


### PR DESCRIPTION
Release notes: https://github.com/fluxcd/flux2/releases/tag/v0.16.1